### PR TITLE
feat: R20-76 Implement Enlarged Image Modal

### DIFF
--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
@@ -1,0 +1,34 @@
+import { IoCloseCircle } from 'react-icons/io5';
+import './enlargedImageModal.css';
+
+type ProductSwiperProps = {
+  currentImage: string;
+  flagDialog: boolean;
+  onclick: () => void;
+};
+
+export const EnlargedImageModal = ({
+  currentImage,
+  flagDialog,
+  onclick,
+}: ProductSwiperProps) => {
+  return (
+    <dialog
+      className={`productDialog ${flagDialog ? 'productDialog_active' : ''}`}
+      onClick={onclick}
+    >
+      <div
+        className="productDialog_container"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div>
+          <IoCloseCircle
+            onClick={onclick}
+            className="ml-auto text-3xl text-moonBlack hover:text-black transition-colors cursor-pointer"
+          />
+        </div>
+        <img className="productDialog__img" src={currentImage} alt="product" />
+      </div>
+    </dialog>
+  );
+};

--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
@@ -1,0 +1,34 @@
+.productDialog{
+  width: 100vw;
+  min-width: 360px;
+  height: 100vh;
+  padding: 5vh 0;
+
+  position: fixed;
+  top: 0;
+
+  background-color: rgba(0, 0, 0, 0.082);
+
+  z-index: 2;
+}
+.productDialog_active{
+  display: flex;
+}
+.productDialog_container{
+  margin: auto;
+
+  padding: 1rem;
+  background-color: white;
+
+  border-radius: 1rem;
+}
+.productDialog__img{
+  height: min-content;
+  object-fit: contain;
+}
+
+@media (min-width: 500px) {
+  .productDialog__img{
+    height: 85vh;
+  }
+}

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { EnlargedImageModal } from './EnlargedImageModal/EnlargedImageModal';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { FreeMode, Thumbs } from 'swiper/modules';
 import { Swiper as SwiperType } from 'swiper/types';
@@ -14,36 +15,54 @@ type ProductSwiperProps = {
 
 export const ProductSwiper = ({ images }: ProductSwiperProps) => {
   const [thumbsSwiper, setThumbsSwiper] = useState<SwiperType | null>(null);
+  const [flagDialog, setFlagDialog] = useState(false);
+  const [currentImage, setCurrentImage] = useState(images[0]);
+
   return (
     <>
-      <Swiper
-        thumbs={{ swiper: thumbsSwiper }}
-        modules={[FreeMode, Thumbs]}
-        centeredSlides={true}
-        className="productImg__main-swiper"
-      >
-        {images.map((img, index) => (
-          <SwiperSlide className="productImg__slide" key={index}>
-            <img src={img} />
-          </SwiperSlide>
-        ))}
-      </Swiper>
-      <Swiper
-        onSwiper={setThumbsSwiper}
-        slidesPerView={5}
-        freeMode={true}
-        centerInsufficientSlides={true}
-        modules={[FreeMode, Thumbs]}
-        className="productImg__footer-swiper"
-      >
-        {images.length > 1
-          ? images.map((img, index) => (
-              <SwiperSlide className="productImg__slide" key={index}>
-                <img src={img} />
-              </SwiperSlide>
-            ))
-          : ''}
-      </Swiper>
+      <div>
+        <Swiper
+          onClick={() => setFlagDialog(true)}
+          onTouchEnd={() => setFlagDialog(true)}
+          thumbs={{ swiper: thumbsSwiper }}
+          modules={[FreeMode, Thumbs]}
+          allowTouchMove={false}
+          centeredSlides={true}
+          className="productImg__main-swiper"
+        >
+          {images.map((img, index) => (
+            <SwiperSlide className="productImg__slide" key={index}>
+              <img
+                src={img}
+                onClick={() => {
+                  setCurrentImage(img);
+                }}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+        <Swiper
+          onSwiper={setThumbsSwiper}
+          slidesPerView={5}
+          freeMode={true}
+          centerInsufficientSlides={true}
+          modules={[FreeMode, Thumbs]}
+          className="productImg__footer-swiper"
+        >
+          {images.length > 1
+            ? images.map((img, index) => (
+                <SwiperSlide className="productImg__slide" key={index}>
+                  <img src={img} />
+                </SwiperSlide>
+              ))
+            : ''}
+        </Swiper>
+      </div>
+      <EnlargedImageModal
+        currentImage={currentImage}
+        flagDialog={flagDialog}
+        onclick={() => setFlagDialog(false)}
+      />
     </>
   );
 };

--- a/src/components/ProductPage/ProductPageSwiper/productSwiper.css
+++ b/src/components/ProductPage/ProductPageSwiper/productSwiper.css
@@ -2,6 +2,7 @@
   display: flex;
   justify-content: center;
   height: inherit;
+  cursor: pointer;
 }
 .productImg__main-swiper{
   height: 511px;

--- a/src/components/ProductPage/productPage.css
+++ b/src/components/ProductPage/productPage.css
@@ -1,6 +1,7 @@
 .productPage{
   @apply font-Inter text-moonBlack;
   padding: 2rem 2vw;
+  min-width: 360px;
 }
 .product{
   display: flex;


### PR DESCRIPTION
# feat: R20-76 Implement Enlarged Image Modal

## Overview 
Implemented modal window with enlarged product image

## Features Implemented
 - Opening modal window on main product picture.
 - The modal window opens with picture that was selected at that moment in the slider.
 - Added button to close modal window
 - Modal window can be closed by button or around picture area.
 - If the screen size becomes smaller than picture, it is proportionally reduced together with the surrounding area.

## Screenshots
![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/e3ea2c6e-ef5a-4ca0-a497-2109e8b81131)



## Checklist
- [x] The product image triggers a modal to open when it is clicked.
- [x] The modal displays an enlarged version of the product image.
- [x] There is a clear way for the user to close the modal.