### PR TITLE
feat: 20-77 Implement Slider Modal

### DIFF
--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
@@ -50,6 +50,7 @@ export const EnlargedImageModal = ({
           controller={{ control: currentImage }}
           onSwiper={setCurrentImage}
           direction="vertical"
+          grabCursor={true}
           mousewheel={true}
           pagination={{
             clickable: true,

--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
@@ -1,13 +1,23 @@
 import { IoCloseCircle } from 'react-icons/io5';
+import { Swiper, SwiperSlide } from 'swiper/react';
+import { FreeMode, Thumbs, Mousewheel, Pagination } from 'swiper/modules';
+import { Swiper as SwiperType } from 'swiper/types';
+import 'swiper/css';
+import 'swiper/css/free-mode';
+import 'swiper/css/zoom';
+import 'swiper/css/navigation';
+import 'swiper/css/pagination';
 import './enlargedImageModal.css';
 
 type ProductSwiperProps = {
-  currentImage: string;
+  images: string[];
+  currentImage: SwiperType | null;
   flagDialog: boolean;
   onclick: () => void;
 };
 
 export const EnlargedImageModal = ({
+  images,
   currentImage,
   flagDialog,
   onclick,
@@ -27,7 +37,28 @@ export const EnlargedImageModal = ({
             className="ml-auto text-3xl text-moonBlack hover:text-black transition-colors cursor-pointer"
           />
         </div>
-        <img className="productDialog__img" src={currentImage} alt="product" />
+        <Swiper
+          modules={[FreeMode, Thumbs, Mousewheel, Pagination]}
+          thumbs={{ swiper: currentImage }}
+          direction="vertical"
+          mousewheel={true}
+          pagination={{
+            clickable: true,
+          }}
+          zoom={true}
+          centeredSlides={true}
+          slidesPerView={1}
+          spaceBetween={5}
+          className="productDialog__img"
+        >
+          {images.map((img, index) => (
+            <SwiperSlide key={index}>
+              <div className="swiper-zoom-container">
+                <img className="object-contain h-full" src={img} />
+              </div>
+            </SwiperSlide>
+          ))}
+        </Swiper>
       </div>
     </dialog>
   );

--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
@@ -1,6 +1,12 @@
 import { IoCloseCircle } from 'react-icons/io5';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { FreeMode, Thumbs, Mousewheel, Pagination } from 'swiper/modules';
+import {
+  FreeMode,
+  Thumbs,
+  Mousewheel,
+  Pagination,
+  Controller,
+} from 'swiper/modules';
 import { Swiper as SwiperType } from 'swiper/types';
 import 'swiper/css';
 import 'swiper/css/free-mode';
@@ -14,6 +20,7 @@ type ProductSwiperProps = {
   currentImage: SwiperType | null;
   flagDialog: boolean;
   onclick: () => void;
+  setCurrentImage: (arg0: SwiperType) => void;
 };
 
 export const EnlargedImageModal = ({
@@ -21,6 +28,7 @@ export const EnlargedImageModal = ({
   currentImage,
   flagDialog,
   onclick,
+  setCurrentImage,
 }: ProductSwiperProps) => {
   return (
     <dialog
@@ -38,18 +46,18 @@ export const EnlargedImageModal = ({
           />
         </div>
         <Swiper
-          modules={[FreeMode, Thumbs, Mousewheel, Pagination]}
-          thumbs={{ swiper: currentImage }}
+          modules={[FreeMode, Thumbs, Mousewheel, Pagination, Controller]}
+          controller={{ control: currentImage }}
+          onSwiper={setCurrentImage}
           direction="vertical"
           mousewheel={true}
           pagination={{
             clickable: true,
           }}
-          zoom={true}
           centeredSlides={true}
           slidesPerView={1}
-          spaceBetween={5}
-          className="productDialog__img"
+          spaceBetween={10}
+          className="productDialog__swiper"
         >
           {images.map((img, index) => (
             <SwiperSlide key={index}>

--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
@@ -6,19 +6,19 @@
 
   position: fixed;
   top: 0;
+  z-index: 2;
 
   background-color: rgba(0, 0, 0, 0.082);
-
-  z-index: 2;
+  cursor: pointer;
 }
 .productDialog_active{
   display: flex;
 }
 .productDialog_container{
   margin: auto;
-
   padding: 1rem;
   background-color: white;
+  cursor: default;
 
   border-radius: 1rem;
 }

--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
@@ -1,6 +1,6 @@
 .productDialog{
   width: 100vw;
-  min-width: 360px;
+  min-width: 340px;
   height: 100vh;
   padding: 5vh 0;
 
@@ -22,7 +22,7 @@
 
   border-radius: 1rem;
 }
-.productDialog__img{
+.productDialog__swiper{
   height: min-content;
   max-width: 100vw;
   max-height: 80vh;

--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/enlargedImageModal.css
@@ -24,11 +24,10 @@
 }
 .productDialog__img{
   height: min-content;
-  object-fit: contain;
+  max-width: 100vw;
+  max-height: 80vh;
 }
 
-@media (min-width: 500px) {
-  .productDialog__img{
-    height: 85vh;
-  }
+.productDialog .swiper-pagination-bullet-active{
+  @apply bg-moonBlack;
 }

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -5,6 +5,7 @@ import { FreeMode, Thumbs, Controller } from 'swiper/modules';
 import { Swiper as SwiperType } from 'swiper/types';
 import 'swiper/css';
 import 'swiper/css/free-mode';
+import 'swiper/css/zoom';
 import 'swiper/css/thumbs';
 import './productSwiper.css';
 
@@ -42,15 +43,20 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
         <Swiper
           onSwiper={setThumbsSwiper}
           slidesPerView={5}
+          spaceBetween={5}
           freeMode={true}
+          watchSlidesProgress={true}
           centerInsufficientSlides={true}
           modules={[FreeMode, Thumbs]}
           className="productImg__footer-swiper"
         >
           {images.length > 1
             ? images.map((img, index) => (
-                <SwiperSlide className="productImg__slide" key={index}>
-                  <img src={img} />
+                <SwiperSlide
+                  className="productImg__slide productImg__footer-slide"
+                  key={index}
+                >
+                  <img className="productImg__footer-img" src={img} />
                 </SwiperSlide>
               ))
             : ''}

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { EnlargedImageModal } from './EnlargedImageModal/EnlargedImageModal';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { FreeMode, Thumbs } from 'swiper/modules';
+import { FreeMode, Thumbs, Controller } from 'swiper/modules';
 import { Swiper as SwiperType } from 'swiper/types';
 import 'swiper/css';
 import 'swiper/css/free-mode';
@@ -21,25 +21,20 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
     <>
       <div>
         <Swiper
-          onClick={(swiper) => {
-            setCurrentImage(swiper);
+          onClick={() => {
             setFlagDialog(true);
           }}
-          onTouchEnd={() => setFlagDialog(true)}
+          controller={{ control: currentImage }}
+          onSwiper={setCurrentImage}
           thumbs={{ swiper: thumbsSwiper }}
-          modules={[FreeMode, Thumbs]}
+          modules={[FreeMode, Thumbs, Controller]}
           allowTouchMove={false}
           centeredSlides={true}
           className="productImg__main-swiper"
         >
           {images.map((img, index) => (
             <SwiperSlide className="productImg__slide" key={index}>
-              <img
-                src={img}
-                // onClick={() => {
-                //   setCurrentImage(img);
-                // }}
-              />
+              <img src={img} />
             </SwiperSlide>
           ))}
         </Swiper>
@@ -65,6 +60,7 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
         currentImage={currentImage}
         flagDialog={flagDialog}
         onclick={() => setFlagDialog(false)}
+        setCurrentImage={setCurrentImage}
       />
     </>
   );

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -5,7 +5,6 @@ import { FreeMode, Thumbs } from 'swiper/modules';
 import { Swiper as SwiperType } from 'swiper/types';
 import 'swiper/css';
 import 'swiper/css/free-mode';
-import 'swiper/css/navigation';
 import 'swiper/css/thumbs';
 import './productSwiper.css';
 
@@ -16,13 +15,16 @@ type ProductSwiperProps = {
 export const ProductSwiper = ({ images }: ProductSwiperProps) => {
   const [thumbsSwiper, setThumbsSwiper] = useState<SwiperType | null>(null);
   const [flagDialog, setFlagDialog] = useState(false);
-  const [currentImage, setCurrentImage] = useState(images[0]);
+  const [currentImage, setCurrentImage] = useState<SwiperType | null>(null);
 
   return (
     <>
       <div>
         <Swiper
-          onClick={() => setFlagDialog(true)}
+          onClick={(swiper) => {
+            setCurrentImage(swiper);
+            setFlagDialog(true);
+          }}
           onTouchEnd={() => setFlagDialog(true)}
           thumbs={{ swiper: thumbsSwiper }}
           modules={[FreeMode, Thumbs]}
@@ -34,9 +36,9 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
             <SwiperSlide className="productImg__slide" key={index}>
               <img
                 src={img}
-                onClick={() => {
-                  setCurrentImage(img);
-                }}
+                // onClick={() => {
+                //   setCurrentImage(img);
+                // }}
               />
             </SwiperSlide>
           ))}
@@ -59,6 +61,7 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
         </Swiper>
       </div>
       <EnlargedImageModal
+        images={images}
         currentImage={currentImage}
         flagDialog={flagDialog}
         onclick={() => setFlagDialog(false)}

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
 import { EnlargedImageModal } from './EnlargedImageModal/EnlargedImageModal';
 import { Swiper, SwiperSlide } from 'swiper/react';
-import { FreeMode, Thumbs, Controller } from 'swiper/modules';
+import { FreeMode, Thumbs, Controller, Navigation } from 'swiper/modules';
 import { Swiper as SwiperType } from 'swiper/types';
 import 'swiper/css';
 import 'swiper/css/free-mode';
 import 'swiper/css/zoom';
+import 'swiper/css/navigation';
 import 'swiper/css/thumbs';
 import './productSwiper.css';
 
@@ -26,10 +27,11 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
           onClick={() => {
             setFlagDialog(true);
           }}
+          navigation={true}
           controller={{ control: mainSlide }}
           onSwiper={setCurrentImage}
           thumbs={{ swiper: thumbsSwiper }}
-          modules={[FreeMode, Thumbs, Controller]}
+          modules={[FreeMode, Thumbs, Controller, Navigation]}
           allowTouchMove={false}
           centeredSlides={true}
           className="productImg__main-swiper"
@@ -42,12 +44,13 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
         </Swiper>
         <Swiper
           onSwiper={setThumbsSwiper}
+          grabCursor={true}
           slidesPerView={5}
           spaceBetween={5}
           freeMode={true}
           watchSlidesProgress={true}
           centerInsufficientSlides={true}
-          modules={[FreeMode, Thumbs]}
+          modules={[FreeMode, Thumbs, Navigation]}
           className="productImg__footer-swiper"
         >
           {images.length > 1

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -15,7 +15,8 @@ type ProductSwiperProps = {
 export const ProductSwiper = ({ images }: ProductSwiperProps) => {
   const [thumbsSwiper, setThumbsSwiper] = useState<SwiperType | null>(null);
   const [flagDialog, setFlagDialog] = useState(false);
-  const [currentImage, setCurrentImage] = useState<SwiperType | null>(null);
+  const [dialogImage, setCurrentImage] = useState<SwiperType | null>(null);
+  const [mainSlide, setMainSlide] = useState<SwiperType | null>(null);
 
   return (
     <>
@@ -24,7 +25,7 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
           onClick={() => {
             setFlagDialog(true);
           }}
-          controller={{ control: currentImage }}
+          controller={{ control: mainSlide }}
           onSwiper={setCurrentImage}
           thumbs={{ swiper: thumbsSwiper }}
           modules={[FreeMode, Thumbs, Controller]}
@@ -57,10 +58,10 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
       </div>
       <EnlargedImageModal
         images={images}
-        currentImage={currentImage}
+        currentImage={dialogImage}
         flagDialog={flagDialog}
         onclick={() => setFlagDialog(false)}
-        setCurrentImage={setCurrentImage}
+        setCurrentImage={setMainSlide}
       />
     </>
   );

--- a/src/components/ProductPage/ProductPageSwiper/productSwiper.css
+++ b/src/components/ProductPage/ProductPageSwiper/productSwiper.css
@@ -4,10 +4,17 @@
   height: inherit;
   cursor: pointer;
 }
+
 .productImg__main-swiper{
   height: 511px;
   margin-bottom: 32px
 }
+.productImg__main-swiper .swiper-button-prev::after,
+.productImg__main-swiper .swiper-button-next::after{
+  padding: 1rem;
+  @apply text-moonBlack;
+}
+
 .productImg__footer-swiper{
   height: 100px;
 }

--- a/src/components/ProductPage/ProductPageSwiper/productSwiper.css
+++ b/src/components/ProductPage/ProductPageSwiper/productSwiper.css
@@ -11,6 +11,14 @@
 .productImg__footer-swiper{
   height: 100px;
 }
-.productImg__footer-swiper img{
+.productImg__footer-slide{
+  opacity: 0.4;
+}
+.productImg__footer-slide.swiper-slide-thumb-active{
+  opacity: 1;
+}
+.productImg__footer-img{
+  position: relative;
+  height: 100%;
   cursor: pointer;
 }


### PR DESCRIPTION
# feat: 20-77 Implement Image Slider in Enlarged Image Modal

## Overview 
Implemented slider in a modal window with an enlarged image
task `RSS-ECOMM-3_13`

## Features Implemented
- Use the mouse wheel, drag and drop and toggle points to switch between slides
- Synchronization between product slider and modal window slider 
- In Thumbs slider inactive slide becomes more transparent 
- Arrow navigation on the main slider

## Screenshots
![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/988a699e-ce8d-4a50-94ef-936ee2f44601)

## Checklist
- [x] The enlarged image modal includes a slider that displays all product images fetched from the API.
- [x] Users can navigate through the images using the slider controls.
