### PR TITLE
feat: R20-75 Implement Product Price

### DIFF
--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -10,11 +10,27 @@ import 'swiper/css/thumbs';
 import './productPage.css';
 import Spinner from '../Spinner';
 
+const convertPrice = function (
+  centAmount: number | undefined,
+  fractionDigits: number | undefined
+) {
+  if (!centAmount || !fractionDigits) return 'No price';
+  const floatAmount = centAmount / Math.pow(10, fractionDigits);
+  return Number.isInteger(floatAmount)
+    ? floatAmount.toFixed(0)
+    : floatAmount.toFixed(fractionDigits);
+};
+
 export const ProductPage = () => {
   const { key } = useParams();
   const { loading, product } = useApiGetProduct(key);
+
   const productData = product?.data.product.masterData.current as ProductAPI;
-  console.log(productData);
+  const price = productData?.masterVariant.prices.find(
+    (priceEl) => priceEl.value.currencyCode === 'EUR'
+  );
+
+  console.log(productData, price);
   return (
     <article className="productPage">
       <Spinner isLoading={loading} />
@@ -27,7 +43,7 @@ export const ProductPage = () => {
             <div className="productData__title">
               <div className="font-bold">{productData.name}</div>
               <div className="font-medium">
-                <span className="mr-4">$35</span>
+                <span className="mr-4">{`${convertPrice(price?.value.centAmount, price?.value.fractionDigits)}€`}</span>
                 <span className="text-moonNeutral-500">$50</span>
               </div>
             </div>

--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -43,8 +43,8 @@ export const ProductPage = () => {
             <div className="productData__title">
               <div className="font-bold">{productData.name}</div>
               <div className="font-medium">
-                <span className="mr-4">{`${convertPrice(price?.value.centAmount, price?.value.fractionDigits)}€`}</span>
-                <span className="text-moonNeutral-500">$50</span>
+                <span className="mr-4">{`${convertPrice(price?.discounted.value.centAmount, price?.discounted.value.fractionDigits)}€`}</span>
+                <span className="text-moonNeutral-500">{`${convertPrice(price?.value.centAmount, price?.value.fractionDigits)}€`}</span>
               </div>
             </div>
             <div>

--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -30,7 +30,6 @@ export const ProductPage = () => {
     (priceEl) => priceEl.value.currencyCode === 'EUR'
   );
 
-  console.log(productData, price);
   return (
     <article className="productPage">
       <Spinner isLoading={loading} />

--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -41,10 +41,25 @@ export const ProductPage = () => {
           </div>
           <div className="product__component productData">
             <div className="productData__title">
-              <div className="font-bold">{productData.name}</div>
-              <div className="font-medium">
-                <span className="mr-4">{`${convertPrice(price?.discounted.value.centAmount, price?.discounted.value.fractionDigits)}€`}</span>
-                <span className="text-moonNeutral-500">{`${convertPrice(price?.value.centAmount, price?.value.fractionDigits)}€`}</span>
+              <div className="text-2xl font-bold">{productData.name}</div>
+              <div className="productData__pricesContainer text-xl font-medium">
+                <span className="productData__discount">
+                  <span
+                    className={`${price?.discounted ? 'productData__valueDiscount text-base' : ''}`}
+                  >
+                    {price?.discounted
+                      ? `-${price?.discounted.discount.value.permyriad / 100}%`
+                      : ''}
+                  </span>
+                  <span className="text-moonBrown">
+                    {price?.discounted
+                      ? `${convertPrice(price?.discounted.value.centAmount, price?.discounted.value.fractionDigits)}€`
+                      : ''}
+                  </span>
+                </span>
+                <span
+                  className={`${price?.discounted ? `text-moonNeutral-500 ml-7` : ''}`}
+                >{`${convertPrice(price?.value.centAmount, price?.value.fractionDigits)}€`}</span>
               </div>
             </div>
             <div>

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -33,6 +33,7 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
           onSwiper={setCurrentImage}
           thumbs={{ swiper: thumbsSwiper }}
           modules={[FreeMode, Thumbs, Controller, Navigation]}
+          spaceBetween={5}
           allowTouchMove={false}
           centeredSlides={true}
           className="productImg__main-swiper"
@@ -60,7 +61,9 @@ export const ProductSwiper = ({ images }: ProductSwiperProps) => {
                   className="productImg__slide productImg__footer-slide"
                   key={index}
                 >
-                  <img className="productImg__footer-img" src={img.url} />
+                  <div className="swiper-zoom-container">
+                    <img className="productImg__footer-img" src={img.url} />
+                  </div>
                 </SwiperSlide>
               ))
             : ''}

--- a/src/components/ProductPage/productPage.css
+++ b/src/components/ProductPage/productPage.css
@@ -17,6 +17,23 @@
 .product__title{
   @apply text-xl;
 }
+.productData__discount{
+  display: flex;
+  flex-direction: column
+}
+.productData__pricesContainer{
+  display: flex;
+  align-items: end;
+}
+.productData__valueDiscount{
+  @apply bg-moonBrown text-moonNeutral-100;
+
+  border-radius: 0.5rem;
+  width: min-content;
+  padding: 2px 2px;
+  margin-bottom: -9%;
+  margin-left: 75%;
+}
 
 .productinfo__title{
   @apply border-moonBlack text-xl font-semibold;

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -105,7 +105,7 @@ export class ProductService {
     locale: string = 'en-US'
   ): Promise<CTResponse> {
     const query = `
-    query($key: String, $locale: Locale) {
+    query ($key: String, $locale: Locale) {
       product(key: $key) {
         key
         masterData {
@@ -115,17 +115,34 @@ export class ProductService {
             description(locale: $locale)
             categories {
               id
-              name(locale:$locale)
+              name(locale: $locale)
             }
             masterVariant {
               images {
                 url
               }
               prices {
-                value{
+                value {
                   fractionDigits
                   centAmount
                   currencyCode
+                }
+                discounted {
+                  value {
+                    centAmount
+                    fractionDigits
+                    currencyCode
+                  }
+                  discount {
+                    id
+                    name(locale: $locale)
+                    value {
+                      type
+                      ... on RelativeDiscountValue {
+                        permyriad
+                      }
+                    }
+                  }
                 }
               }
             }

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -121,6 +121,13 @@ export class ProductService {
               images {
                 url
               }
+              prices {
+                value{
+                  fractionDigits
+                  centAmount
+                  currencyCode
+                }
+              }
             }
           }
         }

--- a/src/type/types/productPageType.ts
+++ b/src/type/types/productPageType.ts
@@ -22,7 +22,7 @@ export type ProductPrice = {
       currencyCode: string;
       fractionDigits: number;
     };
-  };
+  } | null;
 };
 
 export type ProductAPI = {

--- a/src/type/types/productPageType.ts
+++ b/src/type/types/productPageType.ts
@@ -8,6 +8,21 @@ export type ProductPrice = {
     centAmount: number;
     currencyCode: string;
   };
+  discounted: {
+    discount: {
+      id: string;
+      name: string;
+      value: {
+        type: string;
+        permyriad: number;
+      };
+    };
+    value: {
+      centAmount: number;
+      currencyCode: string;
+      fractionDigits: number;
+    };
+  };
 };
 
 export type ProductAPI = {

--- a/src/type/types/productPageType.ts
+++ b/src/type/types/productPageType.ts
@@ -2,6 +2,14 @@ export type ImagesProduct = {
   url: string;
 };
 
+export type ProductPrice = {
+  value: {
+    fractionDigits: number;
+    centAmount: number;
+    currencyCode: string;
+  };
+};
+
 export type ProductAPI = {
   categories: {
     id: string;
@@ -10,6 +18,7 @@ export type ProductAPI = {
   description: string;
   masterVariant: {
     images: ImagesProduct[];
+    prices: ProductPrice[];
   };
   name: string;
 };


### PR DESCRIPTION
# feat: R20-75 Display Product Price and Sale Price

## Overview 
Implemented outputting the product price, and if available, the discount price. Also in commercetools there are discounts for products
task `RSS-ECOMM-3_11`

## Features Implemented
 - Fields to get from commercetools;
 - Types for objects obtained from API;
 - Conversion to the required type and price output;
 - Output of a discount if the product has one;

## Screenshot
![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/41d6e4b5-88c6-4e18-beda-fd9955a60526)

## Checklist
- [x] The application successfully fetches and displays the price for each product from the chosen API.
- [x] If the product is on sale, both the original price and the sale price are displayed. The sale price is clearly distinguished as the current price of the product.
