### PR TITLE
feat: R20-66 Implement Catalog Price

### DIFF
--- a/src/components/CatalogPage/CatalogPage.tsx
+++ b/src/components/CatalogPage/CatalogPage.tsx
@@ -5,7 +5,8 @@ import { SortSection } from '../SortSection/SortSection';
 import { IsLoadindContext } from '../../App';
 import { ProductService } from '../../services';
 import { CTResponse } from '../../ct-client';
-import { Product } from '@commercetools/platform-sdk';
+import { Category, Product } from '@commercetools/platform-sdk';
+import { convertPrice } from '../../utils/convertPrice';
 
 interface ProductsData {
   products: Products;
@@ -98,18 +99,27 @@ export const CatalogPage = () => {
           <section className="flex flex-col gap-5 flex-wrap">
             {allProducts?.total !== 0 ? (
               allProducts?.results.map((element) => {
+                const productData = element?.masterData.current;
+                const price = productData?.masterVariant?.prices?.find(
+                  (priceEl) => priceEl.value.currencyCode === 'EUR'
+                );
+                const basePrice = convertPrice(
+                  price?.value.centAmount,
+                  price?.value.fractionDigits
+                );
                 return (
                   <ProductPreviewItem
                     key={element.key}
                     imgUrl={
-                      element.masterData.current.masterVariant.images
-                        ? `${element.masterData.current.masterVariant.images[0].url}`
+                      productData.masterVariant.images
+                        ? `${productData.masterVariant.images[0].url}`
                         : ''
                     }
-                    productCategory={`${element.masterData.current.categories[0].name}`}
-                    productDescription={`${element.masterData.current.description}`}
-                    productName={`${element.masterData.current.name}`}
-                    productPrice={`$${element.masterData.current.masterVariant.prices ? element.masterData.current.masterVariant.prices[0].value.centAmount : ''}`}
+                    productCategory={`${(productData.categories[0] as unknown as Category).name}`}
+                    productDescription={`${productData.description}`}
+                    productName={`${productData.name}`}
+                    productPrice={`${price?.discounted ? convertPrice(price.discounted.value.centAmount, price.discounted.value.fractionDigits) : basePrice}`}
+                    productOldPrice={price?.discounted ? basePrice : ''}
                   />
                 );
               })

--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -3,23 +3,13 @@ import { ButtonSignUp } from '../UI/ButtonSignUp/ButtonSignUp';
 import { useApiGetProduct } from '../../hooks';
 import { useParams } from 'react-router-dom';
 import { ProductAPI } from '../../type/types/productPageType';
+import { convertPrice } from '../../utils/convertPrice';
 import 'swiper/css';
 import 'swiper/css/free-mode';
 import 'swiper/css/navigation';
 import 'swiper/css/thumbs';
 import './productPage.css';
 import Spinner from '../Spinner';
-
-const convertPrice = function (
-  centAmount: number | undefined,
-  fractionDigits: number | undefined
-) {
-  if (!centAmount || !fractionDigits) return 'No price';
-  const floatAmount = centAmount / Math.pow(10, fractionDigits);
-  return Number.isInteger(floatAmount)
-    ? floatAmount.toFixed(0)
-    : floatAmount.toFixed(fractionDigits);
-};
 
 export const ProductPage = () => {
   const { key } = useParams();

--- a/src/components/ProductPreviewItem/ProductPreviewItem.tsx
+++ b/src/components/ProductPreviewItem/ProductPreviewItem.tsx
@@ -3,6 +3,7 @@ import '@smastrom/react-rating/style.css';
 import { useState } from 'react';
 import { IoCartOutline } from 'react-icons/io5';
 import { MdOutlineViewInAr } from 'react-icons/md';
+import { FaEuroSign } from 'react-icons/fa';
 
 interface ProductPreviewItemProps {
   imgUrl: string;
@@ -10,6 +11,7 @@ interface ProductPreviewItemProps {
   productName: string;
   productDescription: string;
   productPrice: string;
+  productOldPrice: string;
 }
 
 export const ProductPreviewItem = ({
@@ -18,6 +20,7 @@ export const ProductPreviewItem = ({
   productName,
   productDescription,
   productPrice,
+  productOldPrice,
 }: ProductPreviewItemProps) => {
   const [rating, setRating] = useState(3.28);
   return (
@@ -36,7 +39,20 @@ export const ProductPreviewItem = ({
       </div>
       <div className="flex w-2/5 flex-col gap-5 pt-3">
         <div className="flex items-center flex-col gap-2">
-          <p className="font-semibold">{productPrice}</p>
+          <p className="font-semibold flex flex-nowrap">
+            <span
+              className={`flex items-center flex-nowrap ${productOldPrice ? 'text-moonBrown mr-4' : ''}`}
+            >
+              {productPrice}
+              <FaEuroSign />
+            </span>
+            <span
+              className={`text-moonNeutral-500 line-through flex items-center flex-nowrap ${productOldPrice ? '' : 'hidden'}`}
+            >
+              {productOldPrice}
+              <FaEuroSign />
+            </span>
+          </p>
           <Rating
             readOnly
             style={{ maxWidth: 100 }}

--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -198,7 +198,7 @@ export class ProductService {
               categories {
                 id
                 name(locale:$locale)
-            }
+              }
               name(locale: $locale)
               masterVariant {
                 id
@@ -209,7 +209,26 @@ export class ProductService {
                 prices {
                   id
                   value {
+                    fractionDigits
+                    currencyCode
                     centAmount
+                  }
+                  discounted {
+                    value {
+                      centAmount
+                      fractionDigits
+                      currencyCode
+                    }
+                    discount {
+                      id
+                      name(locale: $locale)
+                      value {
+                        type
+                        ... on RelativeDiscountValue {
+                          permyriad
+                        }
+                      }
+                    }
                   }
                 }
                 attributesRaw {

--- a/src/utils/convertPrice.ts
+++ b/src/utils/convertPrice.ts
@@ -1,0 +1,10 @@
+export const convertPrice = function (
+  centAmount: number | undefined,
+  fractionDigits: number | undefined
+) {
+  if (!centAmount || !fractionDigits) return 'No price';
+  const floatAmount = centAmount / Math.pow(10, fractionDigits);
+  return Number.isInteger(floatAmount)
+    ? floatAmount.toFixed(0)
+    : floatAmount.toFixed(fractionDigits);
+};


### PR DESCRIPTION
# feat: R20-66 Display Prices with and Without Discount for Discounted Products 

## Overview 
Implemented price for products in the catalogue, output of prices and discounts
task `RSS-ECOMM-3_02         `

## Features Implemented
 - obtaining complete price and price discount data
 - output product price
 - output the price with discount, if any
 - visually distinguish between the price with and without discount

## Screenshots
![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/5baabcc0-df8d-4c00-8b17-3dd0fd580949)

## Checklist
 - [x] Both the original price and the discounted price are clearly displayed for discounted products.
 - [x] The discounted price is visually distinct and clearly indicates that it is the current price the customer needs to pay.
 - [x]  If the original price is displayed, it should be marked in a way that clearly communicates that it is not the current price (e.g., strikethrough).
