### PR TITLE
feat: R20-136 Fix Header At Top

### DIFF
--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -92,21 +92,23 @@ function Header2() {
   const [showMenu, setShowMenu] = useState(false);
 
   return (
-    <header className="flex flex-row items-center justify-between sm:justify-around p-2 border-b-2 bg-moonNeutral-100 text-moonNeutral-800">
-      <Logo />
-      <nav className="text-lg hidden sm:flex justify-between items-center gap-4 font-semibold">
-        <Links />
-      </nav>
-      <nav className="sm:hidden flex flex-col items-end gap-1 font-semibold">
-        <button
-          onClick={() => setShowMenu(!showMenu)}
-          className="sm:hidden font-bold text-xl hover:text-gray-500"
-        >
-          {showMenu ? <GrClose /> : <GiHamburgerMenu />}
-        </button>
-        {showMenu && <Links />}
-      </nav>
-    </header>
+    <article style={{ height: '58px' }} className="w-full">
+      <header className="flex fixed w-screen z-50 flex-row items-center justify-between sm:justify-around p-2 border-b-2 bg-moonNeutral-100 text-moonNeutral-800">
+        <Logo />
+        <nav className="text-lg hidden sm:flex justify-between items-center gap-4 font-semibold">
+          <Links />
+        </nav>
+        <nav className="sm:hidden flex flex-col items-end gap-1 font-semibold">
+          <button
+            onClick={() => setShowMenu(!showMenu)}
+            className="sm:hidden font-bold text-xl hover:text-gray-500"
+          >
+            {showMenu ? <GrClose /> : <GiHamburgerMenu />}
+          </button>
+          {showMenu && <Links />}
+        </nav>
+      </header>
+    </article>
   );
 }
 


### PR DESCRIPTION
# feat: R20-136 Fix Header At Top

## Overview 
header is fixed on top of the page.

## Features Implemented
- header is fixed at the top of the page
- header in the initial state of the page does not cover its content

## Screenshots
![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/c3e43d56-0e9a-4f31-82cb-d4fd5bcc49ab)

![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/05808434-32c6-4038-ad58-00a66d8725da)