### PR TITLE
refactor: R20-121 Replace Types Price Product

### DIFF
--- a/src/components/CatalogPage/CatalogPage.tsx
+++ b/src/components/CatalogPage/CatalogPage.tsx
@@ -2,7 +2,6 @@ import { FormEvent, useEffect, useState } from 'react';
 import { FilterSection } from '../FilterSection/FilterSection';
 import { SortSection } from '../SortSection/SortSection';
 import { ProductService } from '../../services';
-import { ProductPrice } from '../../type/types/productPageType';
 import { CTResponse } from '../../ct-client';
 import {
   Category,
@@ -191,8 +190,7 @@ export const CatalogPage = () => {
                     productName={`${element.name ? element.name : ''}`}
                     price={
                       element?.masterVariant.prices
-                        ? (element?.masterVariant
-                            .prices[0] as unknown as ProductPrice)
+                        ? element?.masterVariant.prices[0]
                         : undefined
                     }
                   />

--- a/src/components/PriceProduct/PriceProduct.tsx
+++ b/src/components/PriceProduct/PriceProduct.tsx
@@ -1,10 +1,10 @@
-import { ValuePrice } from '../../type/types/productPageType';
+import { TypedMoney } from '@commercetools/platform-sdk';
 import { convertPrice } from '../../utils/convertPrice';
 import './priceProduct.css';
 
 interface ProductPriceProps {
-  initialPrice: ValuePrice;
-  discountPrice?: ValuePrice | undefined;
+  initialPrice: TypedMoney;
+  discountPrice?: TypedMoney | undefined;
   discountValue?: number | undefined;
 }
 

--- a/src/components/PriceProduct/PriceProduct.tsx
+++ b/src/components/PriceProduct/PriceProduct.tsx
@@ -1,18 +1,44 @@
-import { TypedMoney } from '@commercetools/platform-sdk';
+import {
+  ProductDiscount,
+  CartDiscountValueRelative,
+  TypedMoney,
+  Price,
+} from '@commercetools/platform-sdk';
 import { convertPrice } from '../../utils/convertPrice';
 import './priceProduct.css';
 
-interface ProductPriceProps {
+interface PriceProductArguments {
   initialPrice: TypedMoney;
   discountPrice?: TypedMoney | undefined;
   discountValue?: number | undefined;
 }
 
-export const PriceProduct = ({
-  initialPrice,
-  discountPrice = undefined,
-  discountValue = undefined,
-}: ProductPriceProps) => {
+type PriceProductProps = Price | PriceProductArguments;
+
+export const PriceProduct = (price: PriceProductProps) => {
+  const isPriceProductArguments = (
+    price: PriceProductProps
+  ): price is PriceProductArguments => {
+    return (price as PriceProductArguments).initialPrice !== undefined;
+  };
+
+  if (!isPriceProductArguments(price)) {
+    const discount = price?.discounted?.discount as ProductDiscount | undefined;
+    const discountValue = discount?.value as
+      | CartDiscountValueRelative
+      | undefined;
+
+    return (
+      <PriceProduct
+        initialPrice={price.value}
+        discountPrice={price.discounted?.value}
+        discountValue={discountValue?.permyriad}
+      />
+    );
+  }
+
+  const { initialPrice, discountPrice, discountValue } = price;
+
   return (
     <div className="productData__pricesContainer text-xl font-medium">
       <span className="productData__discount">

--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -2,11 +2,7 @@ import { ProductSwiper } from './ProductPageSwiper/ProductSwiper';
 import { PriceProduct } from '../PriceProduct/PriceProduct';
 import { useApiGetProduct } from '../../hooks';
 import { useParams } from 'react-router-dom';
-import {
-  ProductData,
-  ProductDiscount,
-  CartDiscountValueRelative,
-} from '@commercetools/platform-sdk';
+import { ProductData } from '@commercetools/platform-sdk';
 import 'swiper/css';
 import 'swiper/css/free-mode';
 import 'swiper/css/navigation';
@@ -28,10 +24,7 @@ export const ProductPage = () => {
   const price = productData?.masterVariant?.prices?.find(
     (priceEl) => priceEl.value.currencyCode === 'EUR'
   );
-  const discount = price?.discounted?.discount as ProductDiscount | undefined;
-  const discountValue = discount?.value as
-    | CartDiscountValueRelative
-    | undefined;
+
   return (
     <article className="productPage">
       <Spinner isLoading={loading} />
@@ -47,15 +40,7 @@ export const ProductPage = () => {
           <div className="product__component productData">
             <div className="productData__title">
               <div className="text-2xl font-bold">{`${productData.name}`}</div>
-              {price ? (
-                <PriceProduct
-                  initialPrice={price.value}
-                  discountPrice={price.discounted?.value}
-                  discountValue={discountValue?.permyriad}
-                />
-              ) : (
-                'Unavailable'
-              )}
+              {price ? <PriceProduct {...price} /> : 'Unavailable'}
             </div>
             <div>
               <CartControl productId={product?.data.product.id || ''} />

--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -2,7 +2,11 @@ import { ProductSwiper } from './ProductPageSwiper/ProductSwiper';
 import { PriceProduct } from '../PriceProduct/PriceProduct';
 import { useApiGetProduct } from '../../hooks';
 import { useParams } from 'react-router-dom';
-import { ProductAPI } from '../../type/types/productPageType';
+import {
+  ProductData,
+  ProductDiscount,
+  CartDiscountValueRelative,
+} from '@commercetools/platform-sdk';
 import 'swiper/css';
 import 'swiper/css/free-mode';
 import 'swiper/css/navigation';
@@ -20,27 +24,32 @@ export const ProductPage = () => {
     return <NotFoundPage />;
   }
 
-  const productData = product?.data.product.masterData.current as ProductAPI;
-  const price = productData?.masterVariant.prices.find(
+  const productData = product?.data.product.masterData.current as ProductData;
+  const price = productData?.masterVariant?.prices?.find(
     (priceEl) => priceEl.value.currencyCode === 'EUR'
   );
-
+  const discount = price?.discounted?.discount as ProductDiscount | undefined;
+  const discountValue = discount?.value as CartDiscountValueRelative;
   return (
     <article className="productPage">
       <Spinner isLoading={loading} />
       {!loading && (
         <section className="product">
           <div className="product__component productImg">
-            <ProductSwiper images={productData.masterVariant.images} />
+            {productData.masterVariant.images ? (
+              <ProductSwiper images={productData.masterVariant.images} />
+            ) : (
+              ''
+            )}
           </div>
           <div className="product__component productData">
             <div className="productData__title">
-              <div className="text-2xl font-bold">{productData.name}</div>
+              <div className="text-2xl font-bold">{`${productData.name}`}</div>
               {price ? (
                 <PriceProduct
                   initialPrice={price.value}
                   discountPrice={price.discounted?.value}
-                  discountValue={price.discounted?.discount.value.permyriad}
+                  discountValue={discountValue.permyriad}
                 />
               ) : (
                 'Unavailable'
@@ -51,7 +60,7 @@ export const ProductPage = () => {
             </div>
             <div className="productinfo">
               <h3 className="productinfo__title">Details</h3>
-              {productData.description}
+              {`${productData.description}`}
             </div>
           </div>
         </section>

--- a/src/components/ProductPage/ProductPage.tsx
+++ b/src/components/ProductPage/ProductPage.tsx
@@ -29,7 +29,9 @@ export const ProductPage = () => {
     (priceEl) => priceEl.value.currencyCode === 'EUR'
   );
   const discount = price?.discounted?.discount as ProductDiscount | undefined;
-  const discountValue = discount?.value as CartDiscountValueRelative;
+  const discountValue = discount?.value as
+    | CartDiscountValueRelative
+    | undefined;
   return (
     <article className="productPage">
       <Spinner isLoading={loading} />
@@ -49,7 +51,7 @@ export const ProductPage = () => {
                 <PriceProduct
                   initialPrice={price.value}
                   discountPrice={price.discounted?.value}
-                  discountValue={discountValue.permyriad}
+                  discountValue={discountValue?.permyriad}
                 />
               ) : (
                 'Unavailable'

--- a/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/ProductSwiper.tsx
@@ -3,7 +3,7 @@ import { EnlargedImageModal } from './EnlargedImageModal/EnlargedImageModal';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { FreeMode, Thumbs, Controller, Navigation } from 'swiper/modules';
 import { Swiper as SwiperType } from 'swiper/types';
-import { ImagesProduct } from '../../../type/types/productPageType';
+import { Image } from '@commercetools/platform-sdk';
 import 'swiper/css';
 import 'swiper/css/free-mode';
 import 'swiper/css/zoom';
@@ -12,7 +12,7 @@ import 'swiper/css/thumbs';
 import './productSwiper.css';
 
 type ProductSwiperProps = {
-  images: ImagesProduct[];
+  images: Image[];
 };
 
 export const ProductSwiper = ({ images }: ProductSwiperProps) => {

--- a/src/components/ProductPreviewItem/ProductPreviewItem.tsx
+++ b/src/components/ProductPreviewItem/ProductPreviewItem.tsx
@@ -4,10 +4,6 @@ import { useState } from 'react';
 import { MdOutlineViewInAr } from 'react-icons/md';
 import { PriceProduct } from '../PriceProduct/PriceProduct';
 import { Price } from '@commercetools/platform-sdk';
-import {
-  ProductDiscount,
-  CartDiscountValueRelative,
-} from '@commercetools/platform-sdk';
 import { Link } from 'react-router-dom';
 import CartControl from '../CartControl';
 
@@ -31,10 +27,6 @@ export const ProductPreviewItem = ({
   productId,
 }: ProductPreviewItemProps) => {
   const [rating, setRating] = useState(3.28);
-  const discount = price?.discounted?.discount as ProductDiscount | undefined;
-  const discountValue = discount?.value as
-    | CartDiscountValueRelative
-    | undefined;
 
   return (
     <div className="transition duration-700 ease-in-out bg-slate-300 max-w-72 md:max-w-none md:w-full xl:w-4/5 m-auto lg:m-0 rounded p-3 flex flex-col md:flex-row gap-4 md:gap-20 hover:shadow-[1px_1px_8px]">
@@ -57,15 +49,7 @@ export const ProductPreviewItem = ({
       </div>
       <div className="flex w-auto md:w-2/5 flex-col gap-5 pt-3">
         <div className="flex items-center flex-col gap-2">
-          {price ? (
-            <PriceProduct
-              initialPrice={price.value}
-              discountPrice={price.discounted?.value}
-              discountValue={discountValue?.permyriad}
-            />
-          ) : (
-            'Unavailable'
-          )}
+          {price ? <PriceProduct {...price} /> : 'Unavailable'}
           <Rating
             readOnly
             style={{ maxWidth: 100 }}

--- a/src/components/ProductPreviewItem/ProductPreviewItem.tsx
+++ b/src/components/ProductPreviewItem/ProductPreviewItem.tsx
@@ -3,7 +3,11 @@ import '@smastrom/react-rating/style.css';
 import { useState } from 'react';
 import { MdOutlineViewInAr } from 'react-icons/md';
 import { PriceProduct } from '../PriceProduct/PriceProduct';
-import { ProductPrice } from '../../type/types/productPageType';
+import { Price } from '@commercetools/platform-sdk';
+import {
+  ProductDiscount,
+  CartDiscountValueRelative,
+} from '@commercetools/platform-sdk';
 import { Link } from 'react-router-dom';
 import CartControl from '../CartControl';
 
@@ -12,7 +16,7 @@ interface ProductPreviewItemProps {
   productCategory: string;
   productName: string;
   productDescription: string;
-  price: ProductPrice | undefined;
+  price: Price | undefined;
   id: string;
   productId: string;
 }
@@ -27,6 +31,8 @@ export const ProductPreviewItem = ({
   productId,
 }: ProductPreviewItemProps) => {
   const [rating, setRating] = useState(3.28);
+  const discount = price?.discounted?.discount as ProductDiscount | undefined;
+  const discountValue = discount?.value as CartDiscountValueRelative;
 
   return (
     <div className="transition duration-700 ease-in-out bg-slate-300 max-w-72 md:max-w-none md:w-full xl:w-4/5 m-auto lg:m-0 rounded p-3 flex flex-col md:flex-row gap-4 md:gap-20 hover:shadow-[1px_1px_8px]">
@@ -53,7 +59,7 @@ export const ProductPreviewItem = ({
             <PriceProduct
               initialPrice={price.value}
               discountPrice={price.discounted?.value}
-              discountValue={price.discounted?.discount.value.permyriad}
+              discountValue={discountValue.permyriad}
             />
           ) : (
             'Unavailable'

--- a/src/components/ProductPreviewItem/ProductPreviewItem.tsx
+++ b/src/components/ProductPreviewItem/ProductPreviewItem.tsx
@@ -32,7 +32,9 @@ export const ProductPreviewItem = ({
 }: ProductPreviewItemProps) => {
   const [rating, setRating] = useState(3.28);
   const discount = price?.discounted?.discount as ProductDiscount | undefined;
-  const discountValue = discount?.value as CartDiscountValueRelative;
+  const discountValue = discount?.value as
+    | CartDiscountValueRelative
+    | undefined;
 
   return (
     <div className="transition duration-700 ease-in-out bg-slate-300 max-w-72 md:max-w-none md:w-full xl:w-4/5 m-auto lg:m-0 rounded p-3 flex flex-col md:flex-row gap-4 md:gap-20 hover:shadow-[1px_1px_8px]">
@@ -59,7 +61,7 @@ export const ProductPreviewItem = ({
             <PriceProduct
               initialPrice={price.value}
               discountPrice={price.discounted?.value}
-              discountValue={discountValue.permyriad}
+              discountValue={discountValue?.permyriad}
             />
           ) : (
             'Unavailable'

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -36,7 +36,12 @@ function Cart() {
                 </div>
                 <div className="cartProduct__containerPrice flex items-end space-x-4">
                   <PriceProduct
-                    initialPrice={{ centAmount: 25900, fractionDigits: 2 }}
+                    initialPrice={{
+                      type: 'centPrecision',
+                      centAmount: 25900,
+                      fractionDigits: 2,
+                      currencyCode: 'EUE',
+                    }}
                   />
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
@@ -86,8 +91,18 @@ function Cart() {
                 </div>
                 <div className="cartProduct__containerPrice flex items-end space-x-4">
                   <PriceProduct
-                    initialPrice={{ centAmount: 26000, fractionDigits: 2 }}
-                    discountPrice={{ centAmount: 13000, fractionDigits: 2 }}
+                    initialPrice={{
+                      type: 'centPrecision',
+                      centAmount: 26000,
+                      fractionDigits: 2,
+                      currencyCode: 'EUE',
+                    }}
+                    discountPrice={{
+                      type: 'centPrecision',
+                      centAmount: 13000,
+                      fractionDigits: 2,
+                      currencyCode: 'EUE',
+                    }}
                     discountValue={5000}
                   />
                   <svg

--- a/src/type/types/productPageType.ts
+++ b/src/type/types/productPageType.ts
@@ -1,3 +1,5 @@
+import { TypedMoney } from '@commercetools/platform-sdk';
+
 export type ImagesProduct = {
   url: string;
 };
@@ -9,7 +11,7 @@ export type ValuePrice = {
 };
 
 export type ProductPrice = {
-  value: ValuePrice;
+  value: TypedMoney;
   discounted: {
     discount: {
       id: string;
@@ -19,7 +21,7 @@ export type ProductPrice = {
         permyriad: number;
       };
     };
-    value: ValuePrice;
+    value: TypedMoney;
   } | null;
 };
 


### PR DESCRIPTION
# refactor: R20-121 Replace Types Price Product

## Overview 
replaced custom types with commercetools types and added additional functionality to workaround problems with commercetools types. 
task `RSS-ECOMM-4_10`

## Features Implemented
 - Replaced custom types with commercetools types.
 - Added possibility to pass Price type 

## Technical Details
data can be transferred by copying the object of type Price
данные можно передать скопировав объект типа Price 
```
{price ? <PriceProduct {...price} /> : 'Unavailable'}
```
data can be transferred by a destructured object
данные можно передать деструктурированным объектом
```
 <PriceProduct
   initialPrice={{
     type: 'centPrecision',
     centAmount: 26000,
     fractionDigits: 2,
     currencyCode: 'EUE',
   }}
   discsountPrice={{
     type: 'centPrecision',
     centAmount: 13000,
     fractionDigits: 2,
     currencyCode: 'EUE',
   }}
   discountValue={5000}
 />
```
type of destructured object:
тип деструктурированного объекта:
```
interface PriceProductArguments {
 initialPrice: TypedMoney;
 discountPrice?: TypedMoney | undefined;
 discountValue?: number | undefined;
}
```
Due to the structure of commercetools types, in order to use it through a destructured object, you need to register discount processing before the component.
Из-за структуры типов commercetools, чтоб использовать через деструктурированный объект нужно прописать перед компоентом обработку для скидки.
```
 const discount = price?.discounted?.discount as ProductDiscount | undefined;
 const discountValue = discount?.value as
 | CartDiscountValueRelative
 | undefined;
```