### PR TITLE
fix: R20-137 Change Z-Index Of Header And Slider

### DIFF
--- a/src/components/Header2.tsx
+++ b/src/components/Header2.tsx
@@ -92,7 +92,7 @@ function Header2() {
 
   return (
     <article style={{ height: '58px' }} className="w-full">
-      <header className="flex fixed w-screen z-50 flex-row items-center justify-between sm:justify-around p-2 border-b-2 bg-moonNeutral-100 text-moonNeutral-800">
+      <header className="flex fixed w-screen z-40 flex-row items-center justify-between sm:justify-around p-2 border-b-2 bg-moonNeutral-100 text-moonNeutral-800">
         <Logo />
         <nav className="text-lg hidden sm:flex justify-between items-center gap-4 font-semibold">
           <Links />

--- a/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
+++ b/src/components/ProductPage/ProductPageSwiper/EnlargedImageModal/EnlargedImageModal.tsx
@@ -33,7 +33,7 @@ export const EnlargedImageModal = ({
 }: ProductSwiperProps) => {
   return (
     <dialog
-      className={`productDialog ${flagDialog ? 'productDialog_active' : ''}`}
+      className={`productDialog ${flagDialog ? 'productDialog_active z-50' : ''}`}
       onClick={onclick}
     >
       <div


### PR DESCRIPTION
# fix: R20-137 Change Z-Index Of Header And Slider

## Overview 
z-index of title and the page product have been changed so that the enlarged slider is not covered by title. And at the same time, the title overlapped all the other content when scrolling the page.

## Screenshots
![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/e50a12e0-aa62-4994-8994-5bd5520b75c9)

![image](https://github.com/Nikitos32/RSS-eCommerce/assets/74064627/d3c16a01-d1b2-47d5-85f1-481ccd31be45)
